### PR TITLE
Changed - Ajuste nomenclatura

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidTestResultsUserPreferences">
+    <option name="androidTestResultsTableState">
+      <map>
+        <entry key="28629151">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Tests" value="360" />
+                  <entry key="samsung SM-G780G" value="120" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,9 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="All Tests">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/core-analytics/src/main/java/br/ftdev/core/analytics/fake/FakeAnalytics.kt
+++ b/core-analytics/src/main/java/br/ftdev/core/analytics/fake/FakeAnalytics.kt
@@ -10,10 +10,6 @@ class FakeAnalytics {
     _loggedEvents += eventName to Bundle(params)
   }
 
-  fun reset() {
-    _loggedEvents.clear()
-  }
-
   companion object {
     object Event {
       const val SCREEN_VIEW = "screen_view"

--- a/core-data/src/main/java/br/ftdev/core/data/mapper/PokemonMappers.kt
+++ b/core-data/src/main/java/br/ftdev/core/data/mapper/PokemonMappers.kt
@@ -22,7 +22,7 @@ private const val POKEMON_IMAGE_URL = "https://raw.githubusercontent.com/PokeAPI
 object PokemonMappers : KoinComponent {
     private val tracker: EngineeringTracker by inject()
 
-    private fun extractIdFromUrl(url: String): Int? {
+    fun extractIdFromUrl(url: String): Int? {
         return url.trimEnd('/').substringAfterLast('/').toIntOrNull()
     }
 
@@ -36,7 +36,7 @@ object PokemonMappers : KoinComponent {
         )
     }
 
-    private fun PokemonEntity.toDomain(): Pokemon {
+    internal fun PokemonEntity.toDomain(): Pokemon {
         return Pokemon(
             id = id,
             name = name.replaceFirstChar {

--- a/core-data/src/test/java/br/ftdev/core/data/mapper/PokemonMappersTest.kt
+++ b/core-data/src/test/java/br/ftdev/core/data/mapper/PokemonMappersTest.kt
@@ -2,6 +2,9 @@ package br.ftdev.core.data.mapper
 
 import br.ftdev.core.data.local.entity.PokemonDetailsEntity
 import br.ftdev.core.data.local.entity.PokemonEntity
+import br.ftdev.core.data.mapper.PokemonMappers.extractIdFromUrl
+import br.ftdev.core.data.mapper.PokemonMappers.toDomain
+import br.ftdev.core.data.mapper.PokemonMappers.toEntity
 import br.ftdev.core.data.remote.response.PokemonListItemResponse
 import br.ftdev.core.domain.model.Pokemon
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
- Add `toEntity` and `toDomain` mappers functions.
- Refactor `PokemonRepositoryImplTest`.
- Refactor `PokemonMappers` test to use new mapper functions.
- Add `EngineeringTracker` for analytic in `PokemonRepositoryImpl`.
- Update `.idea` files.